### PR TITLE
Add self-hosted runner metrics

### DIFF
--- a/internal/server/api_workflow_metrics_exporter.go
+++ b/internal/server/api_workflow_metrics_exporter.go
@@ -59,7 +59,6 @@ func (c *ApiWorkflowMetricsExporter) StartWorkflowApiPolling(ctx context.Context
 	return nil
 }
 
-// CollectActionBilling collect the action billing.
 func (c *ApiWorkflowMetricsExporter) collectWorkflowApiPolling(ctx context.Context) {
 	queuedWorkflowRuns, _, err := c.GHClient.Actions.ListRepositoryWorkflowRuns(ctx, c.Opts.GitHubOrg, c.Opts.GitHubRepo, &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -74,6 +74,13 @@ var (
 	},
 		[]string{},
 	)
+
+	selfHostedRunnerCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "self_hosted_runner_count",
+		Help: "Number of registered self-hosted runners.",
+	},
+		[]string{"org", "busy", "labels"},
+	)
 )
 
 func init() {
@@ -88,6 +95,7 @@ func init() {
 	prometheus.MustRegister(totalPaidMinutesActions)
 	prometheus.MustRegister(totalMinutesUsedByHostTypeActions)
 	prometheus.MustRegister(workflowQueueSize)
+	prometheus.MustRegister(selfHostedRunnerCount)
 }
 
 type WorkflowObserver interface {

--- a/internal/server/org_runners_metrics_exporter.go
+++ b/internal/server/org_runners_metrics_exporter.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/google/go-github/v66/github"
+	"golang.org/x/oauth2"
+)
+
+type OrgRunnersMetricsExporter struct {
+	GHClient *github.Client
+	Logger   log.Logger
+	Opts     Opts
+}
+
+func NewOrgRunnersMetricsExporter(logger log.Logger, opts Opts) *OrgRunnersMetricsExporter {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: opts.GitHubAPIToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	return &OrgRunnersMetricsExporter{
+		Logger:   logger,
+		Opts:     opts,
+		GHClient: client,
+	}
+}
+
+func (c *OrgRunnersMetricsExporter) StartOrgRunnerApiPolling(ctx context.Context) error {
+	if c.Opts.GitHubOrg == "" {
+		return errors.New("github org not configured")
+	}
+	if c.Opts.GitHubAPIToken == "" {
+		return errors.New("github token not configured")
+	}
+
+	ticker := time.NewTicker(time.Duration(c.Opts.OrgRunnersAPIPollSeconds) * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				c.collectOrgRunnerApiPolling(ctx)
+			case <-ctx.Done():
+				_ = level.Info(c.Logger).Log("msg", "stopped polling for org runner metrics")
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func concatenateLabels(labels []*github.RunnerLabels) string {
+	var concatenatedLabels string
+	for i, label := range labels {
+		concatenatedLabels += label.GetName()
+		if i < len(labels)-1 {
+			concatenatedLabels += "__"
+		}
+	}
+	return concatenatedLabels
+}
+
+func getRunnersPerLabelMap(runners []*github.Runner) map[string]map[string]int {
+	runnersPerLabelMap := make(map[string]map[string]int)
+
+	for _, runner := range runners {
+		if runner.GetStatus() != "online" {
+			continue
+		}
+		labels := concatenateLabels(runner.Labels)
+
+		if _, exists := runnersPerLabelMap[labels]; !exists {
+			runnersPerLabelMap[labels] = make(map[string]int)
+		}
+		if runner.GetBusy() {
+			if _, exists := runnersPerLabelMap[labels]["busy"]; !exists {
+				runnersPerLabelMap[labels]["busy"] = 0
+			}
+			runnersPerLabelMap[labels]["busy"]++
+		} else {
+			if _, exists := runnersPerLabelMap[labels]["idle"]; !exists {
+				runnersPerLabelMap[labels]["idle"] = 0
+			}
+			runnersPerLabelMap[labels]["idle"]++
+		}
+	}
+
+	return runnersPerLabelMap
+}
+
+func (c *OrgRunnersMetricsExporter) collectOrgRunnerApiPolling(ctx context.Context) {
+	orgRunners, _, err := c.GHClient.Actions.ListOrganizationRunners(ctx, c.Opts.GitHubOrg, &github.ListRunnersOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	})
+
+	if err != nil {
+		_ = c.Logger.Log("msg", "failed to retrieve org runner metrics for org", "org", c.Opts.GitHubOrg, "err", err)
+		return
+	}
+
+	runnersPerLabelMap := getRunnersPerLabelMap(orgRunners.Runners)
+
+	for labels, states := range runnersPerLabelMap {
+		for state, count := range states {
+			selfHostedRunnerCount.WithLabelValues(c.Opts.GitHubOrg, state, labels).Set(float64(count))
+		}
+	}
+}

--- a/internal/server/org_runners_metrics_exporter_test.go
+++ b/internal/server/org_runners_metrics_exporter_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v66/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_OrgRunnerMetricsExporter_getRunnersPerLabelMap(t *testing.T) {
+	runners := []*github.Runner{
+		{
+			ID:     github.Int64(1),
+			Name:   github.String("runner1"),
+			Busy:   github.Bool(true),
+			Status: github.String("online"),
+			Labels: []*github.RunnerLabels{{Name: github.String("label1")}, {Name: github.String("label2")}},
+		},
+		{
+			ID:     github.Int64(2),
+			Name:   github.String("runner2"),
+			Busy:   github.Bool(true),
+			Status: github.String("online"),
+			Labels: []*github.RunnerLabels{{Name: github.String("label1")}, {Name: github.String("label2")}},
+		},
+		{
+			ID:     github.Int64(3),
+			Name:   github.String("runner3"),
+			Busy:   github.Bool(true),
+			Status: github.String("online"),
+			Labels: []*github.RunnerLabels{{Name: github.String("label3")}},
+		},
+		{
+			ID:     github.Int64(4),
+			Name:   github.String("runner4"),
+			Busy:   github.Bool(false),
+			Status: github.String("online"),
+			Labels: []*github.RunnerLabels{{Name: github.String("label4")}},
+		},
+		{
+			ID:     github.Int64(5),
+			Name:   github.String("runner5"),
+			Busy:   github.Bool(false),
+			Status: github.String("offline"),
+			Labels: []*github.RunnerLabels{{Name: github.String("label5")}},
+		},
+	}
+
+	result := getRunnersPerLabelMap(runners)
+
+	expected := map[string]map[string]int{
+		"label1__label2": {"busy": 2},
+		"label3":         {"busy": 1},
+		"label4":         {"idle": 1},
+	}
+
+	assert.Equal(t, expected, result)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,12 +23,13 @@ type Opts struct {
 	// GitHub webhook token.
 	GitHubToken string
 	// GitHub API token.
-	GitHubAPIToken          string
-	GitHubOrg               string
-	GitHubUser              string
-	GitHubRepo              string
-	BillingAPIPollSeconds   int
-	WorkflowsAPIPollSeconds int
+	GitHubAPIToken           string
+	GitHubOrg                string
+	GitHubUser               string
+	GitHubRepo               string
+	BillingAPIPollSeconds    int
+	WorkflowsAPIPollSeconds  int
+	OrgRunnersAPIPollSeconds int
 }
 
 type Server struct {
@@ -61,6 +62,12 @@ func NewServer(logger log.Logger, opts Opts) *Server {
 	err = workflowMetricsExporter.StartWorkflowApiPolling(context.TODO())
 	if err != nil {
 		_ = level.Info(logger).Log("msg", fmt.Sprintf("not exporting workflow metrics %v", err))
+	}
+
+	orgRunnersMetricsExporter := NewOrgRunnersMetricsExporter(logger, opts)
+	err = orgRunnersMetricsExporter.StartOrgRunnerApiPolling(context.TODO())
+	if err != nil {
+		_ = level.Info(logger).Log("msg", fmt.Sprintf("not exporting org runner metrics %v", err))
 	}
 
 	muxIngress := http.NewServeMux()

--- a/main.go
+++ b/main.go
@@ -19,17 +19,18 @@ import (
 )
 
 var (
-	listenAddressMetrics          = kingpin.Flag("web.listen-address", "Address to listen on for metrics.").Default(":9101").String()
-	listenAddressIngress          = kingpin.Flag("web.listen-address-ingress", "Address to listen on for web interface and receive webhook.").Default(":8065").String()
-	metricsPath                   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-	ghWebHookPath                 = kingpin.Flag("web.gh-webhook-path", "Path that will be called by the GitHub webhook.").Default("/gh_event").String()
-	githubWebhookToken            = kingpin.Flag("gh.github-webhook-token", "GitHub Webhook Token.").Envar("GITHUB_WEBHOOK_TOKEN").Default("").String()
-	gitHubAPIToken                = kingpin.Flag("gh.github-api-token", "GitHub API Token.").Envar("GITHUB_API_TOKEN").Default("").String()
-	gitHubOrg                     = kingpin.Flag("gh.github-org", "GitHub Organization.").Envar("GITHUB_ORG").Default("").String()
-	gitHubUser                    = kingpin.Flag("gh.github-user", "GitHub User.").Default("").String()
-	gitHubBillingPollingSeconds   = kingpin.Flag("gh.billing-poll-seconds", "Frequency at which to poll billing API.").Envar("BILLING_POLL_SECONDS").Default("120").Int()
-	gitHubRepo                    = kingpin.Flag("gh.github-repo", "GitHub Repo.").Envar("GITHUB_REPO").String()
-	gitHubWorkflowsPollingSeconds = kingpin.Flag("gh.workflows-poll-seconds", "Frequency at which to poll billing workflows.").Envar("WORKFLOWS_POLL_SECONDS").Default("60").Int()
+	listenAddressMetrics           = kingpin.Flag("web.listen-address", "Address to listen on for metrics.").Default(":9101").String()
+	listenAddressIngress           = kingpin.Flag("web.listen-address-ingress", "Address to listen on for web interface and receive webhook.").Default(":8065").String()
+	metricsPath                    = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+	ghWebHookPath                  = kingpin.Flag("web.gh-webhook-path", "Path that will be called by the GitHub webhook.").Default("/gh_event").String()
+	githubWebhookToken             = kingpin.Flag("gh.github-webhook-token", "GitHub Webhook Token.").Envar("GITHUB_WEBHOOK_TOKEN").Default("").String()
+	gitHubAPIToken                 = kingpin.Flag("gh.github-api-token", "GitHub API Token.").Envar("GITHUB_API_TOKEN").Default("").String()
+	gitHubOrg                      = kingpin.Flag("gh.github-org", "GitHub Organization.").Envar("GITHUB_ORG").Default("").String()
+	gitHubUser                     = kingpin.Flag("gh.github-user", "GitHub User.").Default("").String()
+	gitHubBillingPollingSeconds    = kingpin.Flag("gh.billing-poll-seconds", "Frequency at which to poll billing API.").Envar("BILLING_POLL_SECONDS").Default("120").Int()
+	gitHubRepo                     = kingpin.Flag("gh.github-repo", "GitHub Repo.").Envar("GITHUB_REPO").String()
+	gitHubWorkflowsPollingSeconds  = kingpin.Flag("gh.workflows-poll-seconds", "Frequency at which to poll workflows.").Envar("WORKFLOWS_POLL_SECONDS").Default("60").Int()
+	githubOrgRunnersPollingSeconds = kingpin.Flag("gh.org-runners-poll-seconds", "Frequency at which to poll org runners.").Envar("ORG_RUNNERS_POLL_SECONDS").Default("60").Int()
 )
 
 func init() {
@@ -56,17 +57,18 @@ func main() {
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
 	srv := server.NewServer(logger, server.Opts{
-		WebhookPath:             *ghWebHookPath,
-		ListenAddressMetrics:    *listenAddressMetrics,
-		ListenAddressIngress:    *listenAddressIngress,
-		MetricsPath:             *metricsPath,
-		GitHubToken:             *githubWebhookToken,
-		GitHubAPIToken:          *gitHubAPIToken,
-		GitHubUser:              *gitHubUser,
-		GitHubOrg:               *gitHubOrg,
-		GitHubRepo:              *gitHubRepo,
-		BillingAPIPollSeconds:   *gitHubBillingPollingSeconds,
-		WorkflowsAPIPollSeconds: *gitHubWorkflowsPollingSeconds,
+		WebhookPath:              *ghWebHookPath,
+		ListenAddressMetrics:     *listenAddressMetrics,
+		ListenAddressIngress:     *listenAddressIngress,
+		MetricsPath:              *metricsPath,
+		GitHubToken:              *githubWebhookToken,
+		GitHubAPIToken:           *gitHubAPIToken,
+		GitHubUser:               *gitHubUser,
+		GitHubOrg:                *gitHubOrg,
+		GitHubRepo:               *gitHubRepo,
+		BillingAPIPollSeconds:    *gitHubBillingPollingSeconds,
+		WorkflowsAPIPollSeconds:  *gitHubWorkflowsPollingSeconds,
+		OrgRunnersAPIPollSeconds: *githubOrgRunnersPollingSeconds,
 	})
 	go func() {
 		err := srv.Serve(context.Background())


### PR DESCRIPTION
* Add current counts per label(s) and state (busy/idle).
* Only consider online runners

```
self_hosted_runner_count{busy="busy",labels="self-hosted__Linux__X64__aws__prd__aws-x64__default",org="fernride"} 5
self_hosted_runner_count{busy="busy",labels="self-hosted__Linux__X64__aws__prd__coverage",org="fernride"} 3
self_hosted_runner_count{busy="busy",labels="self-hosted__Linux__X64__aws__prd__coverage-report",org="fernride"} 1
self_hosted_runner_count{busy="busy",labels="self-hosted__Linux__X64__aws__prd__e2e",org="fernride"} 1
self_hosted_runner_count{busy="busy",labels="self-hosted__Linux__X64__aws__prd__sanitizers",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__aws-x64-qnx__aws__qnx__prd",org="fernride"} 2
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__aws__prd__coverage-report",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__aws__prd__e2e",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__aws__prd__release",org="fernride"} 3
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__onprem-brci",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__onprem-breadboard-jumpserver",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__onprem-n4-cibench-jumpserver",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__onprem-n4-jumpserver",org="fernride"} 1
self_hosted_runner_count{busy="idle",labels="self-hosted__Linux__X64__onprem-x64",org="fernride"} 1
```